### PR TITLE
# Version 0.3 (2015-11-11) - KSP 1.0.5 update.

### DIFF
--- a/LETech-CHANGELOG.txt
+++ b/LETech-CHANGELOG.txt
@@ -1,3 +1,11 @@
+0.3 (2015-11-11) - KSP 1.0.5 update.
+ - Switched the 4-man capsule's "generic" IVA over to use the Mk3 shuttle's IVA instead, so that all 4 Kerbals are EVA/IVA selectable.
+ - Moved "CHANGELOG" to the mod's directory.
+ - Updated bays to use current cargo bay thermal stats and allow door deployment limit.
+ - Parachutes now use new contract constraints.
+ - Command pods use new maxTemp and slinMaxTemp values.
+ - 4-man capsule uses new buoyancy settings.
+
 0.2.1 (2015-08-05) - Alpha fixes.
  - Fixed a texture problem that resulted in the 1m and 2m fixed ladders not loading textures.
  - Fixed a scaling error with the "large" octagonal bay's doors, causing it to leave gaps when closed.

--- a/LETech/Parts/Bays/LETbay2mExp.cfg
+++ b/LETech/Parts/Bays/LETbay2mExp.cfg
@@ -34,10 +34,8 @@ PART
 	angularDrag = 2
 	crashTolerance = 14
 	bulkheadProfiles = size2
-	maxTemp = 2900
-	heatConductivity = 0.04
-	thermalMassModifier = 5.0 
-	emissiveConstant = 0.95
+	maxTemp = 2600
+	emissiveConstant = 0.8
 	
 	MODULE
 	{
@@ -47,6 +45,10 @@ PART
 		startEventGUIName = Open
 		endEventGUIName = Close
 		allowAnimationWhileShielded = False
+		allowDeployLimit = true
+		revClampDirection = false
+		revClampSpeed = true
+		revClampPercent = true
 	}
 
 	MODULE
@@ -73,12 +75,5 @@ PART
 	{
 		name = FlagDecal
 		textureQuadName = flagDecal
-	}
-
-	MODULE
-	{
-		name = ModuleConductionMultiplier
-		modifiedConductionFactor = 0.001
-		convectionFluxThreshold = 500
 	}
 }

--- a/LETech/Parts/Bays/LETbay2mOct1.cfg
+++ b/LETech/Parts/Bays/LETbay2mOct1.cfg
@@ -42,10 +42,8 @@ PART
 	crashTolerance = 14
 	bulkheadProfiles = size2
 
-	maxTemp = 2900
-	heatConductivity = 0.04
-	thermalMassModifier = 5.0 
-	emissiveConstant = 0.95
+	maxTemp = 2600
+	emissiveConstant = 0.8
 
 	stackSymmetry = 3
 	
@@ -57,6 +55,10 @@ PART
 		startEventGUIName = Open
 		endEventGUIName = Close
 		allowAnimationWhileShielded = False
+		allowDeployLimit = true
+		revClampDirection = false
+		revClampSpeed = true
+		revClampPercent = true
 	}
 
 	MODULE
@@ -92,13 +94,6 @@ PART
 		actionGUIName = Toggle Lights
 		startEventGUIName = Lights On
 		endEventGUIName = Lights Off
-	}
-
-	MODULE
-	{
-		name = ModuleConductionMultiplier
-		modifiedConductionFactor = 0.001
-		convectionFluxThreshold = 500
 	}
 
 	RESOURCE

--- a/LETech/Parts/Bays/LETbay2mOct2.cfg
+++ b/LETech/Parts/Bays/LETbay2mOct2.cfg
@@ -42,10 +42,8 @@ PART
 	crashTolerance = 14
 	bulkheadProfiles = size2
 
-	maxTemp = 2900
-	heatConductivity = 0.04
-	thermalMassModifier = 5.0 
-	emissiveConstant = 0.95
+	maxTemp = 2600
+	emissiveConstant = 0.8
 
 	stackSymmetry = 3
 	
@@ -57,6 +55,10 @@ PART
 		startEventGUIName = Open
 		endEventGUIName = Close
 		allowAnimationWhileShielded = False
+		allowDeployLimit = true
+		revClampDirection = false
+		revClampSpeed = true
+		revClampPercent = true
 	}
 
 	MODULE
@@ -92,13 +94,6 @@ PART
 		actionGUIName = Toggle Lights
 		startEventGUIName = Lights On
 		endEventGUIName = Lights Off
-	}
-
-	MODULE
-	{
-		name = ModuleConductionMultiplier
-		modifiedConductionFactor = 0.001
-		convectionFluxThreshold = 500
 	}
 
 	RESOURCE

--- a/LETech/Parts/Chutes/LETchute1m.cfg
+++ b/LETech/Parts/Chutes/LETchute1m.cfg
@@ -14,6 +14,7 @@ PART
 	node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	node_attach = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0
 
+	buoyancyUseCubeNamed = PACKED
 	sound_parachute_open = activate
 
 	TechRequired = advLanding
@@ -60,9 +61,157 @@ PART
 	MODULE
 	{
 		name = ModuleTestSubject
-		environments = 4
 		useStaging = True
 		useEvent = False
+		situationMask = 8
+		CONSTRAINT
+		{
+			type = ATMOSPHERE
+			value = True
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 200
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 100
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 100
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 50
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 50
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 20
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.2
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.1
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.02
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDE
+			test = GT
+			value = 1000
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 4000
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 8000
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 2000
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 4000
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 1000
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 2000
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = SPEED
+			test = LT
+			value = 300
+			body = _Home
+		}
+		CONSTRAINT
+		{
+			type = SPEED
+			test = LT
+			value = 1000
+			body = _NotHome
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = ALWAYS
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = BODYANDSITUATION
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = ONCEPERPART
+			prestige = Exceptional
+		}
 	}
 	MODULE
 	{

--- a/LETech/Parts/Chutes/LETchute2m.cfg
+++ b/LETech/Parts/Chutes/LETchute2m.cfg
@@ -14,6 +14,7 @@ PART
 	node_stack_bottom = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0, 1
 	node_attach = 0.0, -0.2, 0.0, 0.0, -1.0, 0.0
 
+	buoyancyUseCubeNamed = PACKED
 	sound_parachute_open = activate
 
 	TechRequired = heavyLanding
@@ -60,9 +61,157 @@ PART
 	MODULE
 	{
 		name = ModuleTestSubject
-		environments = 4
 		useStaging = True
 		useEvent = False
+		situationMask = 8
+		CONSTRAINT
+		{
+			type = ATMOSPHERE
+			value = True
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 200
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 100
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 100
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 50
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 50
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 20
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.2
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.1
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.02
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDE
+			test = GT
+			value = 1000
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 4000
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 8000
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 2000
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 4000
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 1000
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 2000
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = SPEED
+			test = LT
+			value = 300
+			body = _Home
+		}
+		CONSTRAINT
+		{
+			type = SPEED
+			test = LT
+			value = 1000
+			body = _NotHome
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = ALWAYS
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = BODYANDSITUATION
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = ONCEPERPART
+			prestige = Exceptional
+		}
 	}
 	MODULE
 	{

--- a/LETech/Parts/Chutes/LETchuteR1.cfg
+++ b/LETech/Parts/Chutes/LETchuteR1.cfg
@@ -13,6 +13,7 @@ PART
 	rescaleFactor = 1.0
 	node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
 
+	buoyancyUseCubeNamed = PACKED
 	sound_parachute_open = activate
 
 	TechRequired = heavyLanding
@@ -59,9 +60,157 @@ PART
 	MODULE
 	{
 		name = ModuleTestSubject
-		environments = 4
 		useStaging = True
 		useEvent = False
+		situationMask = 8
+		CONSTRAINT
+		{
+			type = ATMOSPHERE
+			value = True
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 200
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 100
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 100
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 50
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = LT
+			value = 50
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = SPEEDENV
+			test = GT
+			value = 20
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.2
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.1
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = DENSITY
+			test = GT
+			value = 0.02
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDE
+			test = GT
+			value = 1000
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 4000
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 8000
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 2000
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 4000
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = GT
+			value = 1000
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = ALTITUDEENV
+			test = LT
+			value = 2000
+			prestige = Exceptional
+		}
+		CONSTRAINT
+		{
+			type = SPEED
+			test = LT
+			value = 300
+			body = _Home
+		}
+		CONSTRAINT
+		{
+			type = SPEED
+			test = LT
+			value = 1000
+			body = _NotHome
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = ALWAYS
+			prestige = Trivial
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = BODYANDSITUATION
+			prestige = Significant
+		}
+		CONSTRAINT
+		{
+			type = REPEATABILITY
+			value = ONCEPERPART
+			prestige = Exceptional
+		}
 	}
 	MODULE
 	{

--- a/LETech/Parts/Pods/LETlander2mX3.cfg
+++ b/LETech/Parts/Pods/LETlander2mX3.cfg
@@ -31,7 +31,8 @@ PART
 	minimum_drag = 0.15
 	angularDrag = 2
 	crashTolerance = 9
-	maxTemp = 2000 // = 3400
+	maxTemp = 1000
+	skinMaxTemp = 2000
 
 	vesselType = Lander
 	CrewCapacity = 3

--- a/LETech/Parts/Pods/LETpod2m4k.cfg
+++ b/LETech/Parts/Pods/LETpod2m4k.cfg
@@ -17,6 +17,10 @@ PART
 
 	CoPOffset = 0.0, 0.6, 0.0
 	CoLOffset = 0.0, -0.45, 0.0
+	CenterOfBuoyancy = 0.0, 0.8, 0.0
+	CenterOfDisplacement = 0.0, -0.5, 0.0
+	buoyancyUseSine = False
+	buoyancy = 1.1
 
 	TechRequired = commandModules
 	entryCost = 12000
@@ -34,7 +38,8 @@ PART
 	minimum_drag = 0.15
 	angularDrag = 2
 	crashTolerance = 45
-	maxTemp = 2400 // = 3400
+	maxTemp = 1400
+	skinMaxTemp = 2400
 
 	vesselType = Ship
 	CrewCapacity = 4
@@ -43,7 +48,7 @@ PART
 
 	INTERNAL
 	{
-		name = GenericSpace3
+		name = MK3_Cockpit_Int	// GenericSpace3
 	}
 	MODULE
 	{

--- a/LithobrakeExplorationTechnologies.version
+++ b/LithobrakeExplorationTechnologies.version
@@ -12,8 +12,8 @@
 	"VERSION" :
 	{
 		"MAJOR" : 0,
-		"MINOR" : 2,
-		"PATCH" : 1,
+		"MINOR" : 3,
+		"PATCH" : 0,
 		"BUILD" : 0
 	},
 	"KSP_VERSION" :


### PR DESCRIPTION
# Version 0.3 (2015-11-11) - KSP 1.0.5 update.
* Switched the 4-man capsule's "generic" IVA over to use the Mk3 shuttle's IVA instead, so that all 4 Kerbals are EVA/IVA selectable.
* Moved "CHANGELOG" to the mod's directory.
* Updated bays to use current cargo bay thermal stats and allow door deployment limit.
* Parachutes now use new contract constraints.
* Command pods use new maxTemp and skinMaxTemp values.
* 4-man capsule uses new buoyancy settings.
* updates #9
* closes #15